### PR TITLE
fixed _unwrap function for value=0

### DIFF
--- a/lib/node_cache.coffee
+++ b/lib/node_cache.coffee
@@ -340,7 +340,10 @@ module.exports = class NodeCache extends EventEmitter
 	#
 	# internal method to extract get the value out of the wrapped value
 	_unwrap: ( value )=>
-		value.v or null
+		if value.v is 0 
+			0
+		else
+			value.v or null
 	
 	# ## _getKeyLength
 	#
@@ -379,5 +382,5 @@ module.exports = class NodeCache extends EventEmitter
 			cb( error, null )
 			return
 		else
-			# if no callbach is defined return the error object
+			# if no callback is defined return the error object
 			error

--- a/lib/node_cache.js
+++ b/lib/node_cache.js
@@ -223,7 +223,11 @@
     };
 
     NodeCache.prototype._unwrap = function(value) {
-      return value.v || null;
+      if (value.v === 0) {
+        return 0;
+      } else {
+        return value.v || null;
+      }
     };
 
     NodeCache.prototype._getKeyLength = function(key) {


### PR DESCRIPTION
I've added a check for value === 0 in _unwrap function, because otherwise it will return null when retrieving from cache {key:0}
