### PR TITLE
take() method added for single-read values

### DIFF
--- a/_src/lib/node_cache.coffee
+++ b/_src/lib/node_cache.coffee
@@ -303,7 +303,7 @@ module.exports = class NodeCache extends EventEmitter
 	#
 	take: ( key )=>
 		_ret = @get(key)
-		if (_ret) 
+		if (_ret?) 
 			@del(key)
 		return _ret
 

--- a/_src/lib/node_cache.coffee
+++ b/_src/lib/node_cache.coffee
@@ -287,6 +287,26 @@ module.exports = class NodeCache extends EventEmitter
 
 		return delCount
 
+	# ## take
+	#
+	# get the cached value and remove the key from the cache.
+	# Equivalent to calling `get(key)` + `del(key)`.
+	# Useful for implementing `single use` mechanism such as OTP, where once a value is read it will become obsolete.
+	#
+	# **Parameters:**
+	#
+	# * `key` ( String | Number ): cache key
+	#
+	# **Example:**
+	#
+	#	myCache.take "myKey", ( err, val )
+	#
+	take: ( key )=>
+		_ret = @get(key)
+		if (_ret) 
+			@del(key)
+		return _ret
+
 	# ## ttl
 	#
 	# reset or redefine the ttl of a key. `ttl` = 0 means infinite lifetime.

--- a/_src/test/mocha_test.coffee
+++ b/_src/test/mocha_test.coffee
@@ -70,6 +70,7 @@ describe "`#{pkg.name}@#{pkg.version}` on `node@#{process.version}`", () ->
 					b:
 						x: 2
 						y: 3
+				otp: randomString 10
 			return
 
 		it "set key", () ->
@@ -101,6 +102,50 @@ describe "`#{pkg.name}@#{pkg.version}` on `node@#{process.version}`", () ->
 		it "delete an undefined key", () ->
 			count = localCache.del "xxx"
 			0.should.eql count
+			return
+
+		it "take key", () ->
+			# make sure we are starting fresh
+			res = localCache.has("otp")
+			res.should.eql false
+
+			# taking a non-exitent value should be fine
+			res = localCache.take("otp")
+			should.not.exist(res)
+
+			# check if otp insertion suceeded
+			res = localCache.set "otp", state.otp, 0
+			true.should.eql res
+
+			# are we able to check the presence of the key?
+			res = localCache.has("otp")
+			res.should.eql true
+
+			# not once, but twice?
+			# This proves that keys can be accessed as many times as required, but 
+			# not the value. The `take()` method makes the values as single-read, not the keys.
+			res = localCache.has("otp")
+			res.should.eql true
+
+			# take the value
+			otp = localCache.take("otp")
+			otp.should.eql state.otp
+
+			# key should not be present anymore once the value is read
+			res = localCache.has("otp")
+			res.should.eql false
+
+			# and, re-insertions are not probhitied
+			res = localCache.set "otp", "some other value"
+			true.should.eql res
+
+			# should be able take the value again
+			otp = localCache.take("otp")
+			otp.should.eql "some other value"
+
+			# key should not be present anymore, again
+			res = localCache.has("otp")
+			res.should.eql false					
 			return
 
 		it "update key (and get it to check if the update worked)", () ->

--- a/_src/test/mocha_test.coffee
+++ b/_src/test/mocha_test.coffee
@@ -148,6 +148,22 @@ describe "`#{pkg.name}@#{pkg.version}` on `node@#{process.version}`", () ->
 			res.should.eql false					
 			return
 
+		it "take key with falsy values", () ->
+			# make sure we are starting fresh
+			res = localCache.has("otp")
+			res.should.eql false
+
+			# insert a falsy value and take it
+			res = localCache.set "otp", 0
+			true.should.eql res
+			otp = localCache.take("otp")
+			otp.should.eql 0
+
+			# key should not exist anymore
+			res = localCache.has("otp")
+			res.should.eql false
+			return
+
 		it "update key (and get it to check if the update worked)", () ->
 			res = localCache.set state.key, state.value2, 0
 			true.should.eql res

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "node": ">= 0.4.6"
   },
   "scripts": {
-    "test": "mocha --require coffee-script/register --require coffee-coverage/register-istanbul _src/test/mocha_test.coffee -R spec && tsc",
+    "test": "COFFEECOV_INIT_ALL=false mocha --require coffee-script/register --require coffee-coverage/register-istanbul _src/test/mocha_test.coffee -R spec && tsc",
     "build": "grunt build"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "node": ">= 0.4.6"
   },
   "scripts": {
-    "test": "COFFEECOV_INIT_ALL=false mocha --require coffee-script/register --require coffee-coverage/register-istanbul _src/test/mocha_test.coffee -R spec && tsc",
+    "test": "mocha --require coffee-script/register --require coffee-coverage/register-istanbul _src/test/mocha_test.coffee -R spec && tsc",
     "build": "grunt build"
   },
   "dependencies": {


### PR DESCRIPTION
Fix for https://github.com/node-cache/node-cache/issues/159

Single-use tokens (such as OTPs) cannot be used under two circumstances:
- time expired,
- already used

TTL solves the first problem. This `take` method aims to solve the second problem. The value could be active (TTL not expired), but if it is already "touched" (get() called for verification), then just delete it, so that no replay attack is possible.