### PR TITLE
Update README.md docs for GET operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ const success = myCache.mset([
 
 Gets a saved value from the cache.
 Returns a `undefined` if not found or expired.
-If the value was found it returns an object with the `key` `value` pair.
+If the value was found it returns the `value`.
 
 ```js
 value = myCache.get( "myKey" );


### PR DESCRIPTION
As far as I can see locally, calling `myCache.get( key )` returns the value, not a key value pair as mentioned in the documentation. 

This is a simple wording change to clarify that.