### PR TITLE
Added flushStats to NodeCache ambient declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -358,6 +358,11 @@ declare class NodeCache extends events.EventEmitter {
 	 * This will clear the interval timeout which is set on checkperiod option.
 	 */
 	close(): void;
+
+	/**
+	 * flush the stats and reset all counters to 0
+	 */
+	flushStats(): void;
 }
 
 


### PR DESCRIPTION
The current `index.d.ts` ambient declarations file looks to be missing a declaration for the recent addition of`flushStats`. This PR adds that declaration.