### PR TITLE
Fix running with Jest's Fake Timers

### DIFF
--- a/_src/lib/node_cache.coffee
+++ b/_src/lib/node_cache.coffee
@@ -545,7 +545,7 @@ module.exports = class NodeCache extends EventEmitter
 
 		if startPeriod and @options.checkperiod > 0
 			@checkTimeout = setTimeout( @_checkData, ( @options.checkperiod * 1000 ), startPeriod )
-			@checkTimeout.unref() if @checkTimeout.unref?
+			@checkTimeout.unref() if @checkTimeout? && @checkTimeout.unref?
 		return
 
 	# ## _killCheckPeriod


### PR DESCRIPTION
If you call `cache.set(value)` while using `jest.useFakeTimers()` you will get a null pointer due to `setTimeout` and `setInterval` returning `undefined`. This adds a null check that fixes this.

Fixes #172 