### PR TITLE
fix #197 "ReferenceError: Buffer is not defined" in environments wher…

### DIFF
--- a/_src/lib/node_cache.coffee
+++ b/_src/lib/node_cache.coffee
@@ -645,7 +645,7 @@ module.exports = class NodeCache extends EventEmitter
 			# if the data is a Promise, use defined default
 			# (can't calculate actual/resolved value size synchronously)
 			@options.promiseValueSize
-		else if Buffer.isBuffer(value)
+		else if Buffer?.isBuffer(value)
 			value.length
 		else if value? and typeof value is "object"
 			# if the data is an Object multiply each element with a defined default length

--- a/_src/test/mocha_test.coffee
+++ b/_src/test/mocha_test.coffee
@@ -1243,5 +1243,31 @@ describe "`#{pkg.name}@#{pkg.version}` on `node@#{process.version}`", () ->
 			)
 			return
 		)
+
+		describe("#197 - ReferenceError: Buffer is not defined (maybe we should have a general 'browser compatibility' test-suite?", () ->
+			cache = null
+			globalBuffer = global.Buffer
+
+			before(() ->
+				# make `Buffer` globally unavailable
+				# we have to explicitly set to `undefined` because our `clone` dependency checks for that
+				global.Buffer = undefined
+				cache = new nodeCache()
+				return
+			)
+
+			it("should not throw when setting a of key of type `object` (or any other type that gets tested after `Buffer` in `_getValLength()`) when `Buffer` is not available in the global scope", () ->
+				should(Buffer).be.undefined()
+				cache.set("foo", {})
+				return
+			)
+
+			after(() ->
+				global.Buffer = globalBuffer
+				should(Buffer).eql(globalBuffer)
+			)
+			return
+		)
+
 		return
 	return

--- a/_src/test/mocha_test.coffee
+++ b/_src/test/mocha_test.coffee
@@ -1256,7 +1256,7 @@ describe "`#{pkg.name}@#{pkg.version}` on `node@#{process.version}`", () ->
 				return
 			)
 
-			it("should not throw when setting a of key of type `object` (or any other type that gets tested after `Buffer` in `_getValLength()`) when `Buffer` is not available in the global scope", () ->
+			it("should not throw when setting a key of type `object` (or any other type that gets tested after `Buffer` in `_getValLength()`) when `Buffer` is not available in the global scope", () ->
 				should(Buffer).be.undefined()
 				cache.set("foo", {})
 				return


### PR DESCRIPTION
…e Buffer is not available

- add test that globally unsets Buffer and tests the erroneous code path
- fix code path: check for `Buffer` existence first