### PR TITLE
Add fetch method

### DIFF
--- a/_src/lib/node_cache.coffee
+++ b/_src/lib/node_cache.coffee
@@ -205,11 +205,11 @@ module.exports = class NodeCache extends EventEmitter
 	#
 	# * `key` ( String | Number ): cache key
 	# * `[ ttl ]` ( Number | String ): ( optional ) The time to live in seconds.
-	# * `value` ( Function | Any ): if Function is given, its return value will be fetched, otherwise the value itself is fetched
+	# * `value` ( Any ): if `Function` type is given, it will be executed and returned value will be fetched, otherwise the value itself is fetched
 	#
 	# **Example:**
 	#
-	#	myCache.fetch "myKey", 10, () => "my_String value"
+	# myCache.fetch "myKey", 10, () => "my_String value"
 	#
 	# myCache.fetch "myKey", "my_String value"
 	#

--- a/_src/lib/node_cache.coffee
+++ b/_src/lib/node_cache.coffee
@@ -197,6 +197,30 @@ module.exports = class NodeCache extends EventEmitter
 		# return true
 		return true
 	
+	# ## fetch
+	#
+	# in the event of a cache miss (no value is assinged to given cache key), value will be written to cache and returned. In case of cache hit, cached value will be returned without executing given value. If the given value is type of `Function`, it will be executed and returned result will be fetched
+	#
+	# **Parameters:**
+	#
+	# * `key` ( String | Number ): cache key
+	# * `[ ttl ]` ( Number | String ): ( optional ) The time to live in seconds.
+	# * `value` ( Function | Any ): if Function is given, its return value will be fetched, otherwise the value itself is fetched
+	#
+	# **Example:**
+	#
+	#	myCache.fetch "myKey", 10, () => "my_String value"
+	#
+	# myCache.fetch "myKey", "my_String value"
+	#
+	fetch: ( key, ttl, value )=>
+		# check if cache is hit
+		_ret = @get( key )
+		if _ret?
+			return _ret
+		_ret = if typeof value == 'function' then value() else value
+		@set( key, _ret, ttl )
+		return _ret
 
 	# ## mset
 	#

--- a/_src/test/mocha_test.coffee
+++ b/_src/test/mocha_test.coffee
@@ -1223,6 +1223,35 @@ describe "`#{pkg.name}@#{pkg.version}` on `node@#{process.version}`", () ->
 			return
 
 		return
+  
+	describe "fetch", () ->
+		beforeEach () ->
+				localCache.flushAll()
+				state =
+					func: () -> 
+						return 'foo'
+		
+		context 'when value is type of Function', () ->
+			it 'execute it and fetch returned value', () ->
+				'foo'.should.eql localCache.fetch( 'key', 100, state.func )
+				return
+
+		context 'when value is not a function', () ->
+			it 'return the value itself', () ->
+				'bar'.should.eql localCache.fetch( 'key', 100, 'bar' )
+				return
+
+		context 'cache hit', () ->
+			it 'return cached value', () ->
+				localCache.set 'key', 'bar', 100
+				'bar'.should.eql localCache.fetch( 'key', 100, state.func )
+				return
+
+		context 'cache miss', () ->
+			it 'write given value to cache and return it', () ->
+				'foo'.should.eql localCache.fetch( 'key', 100, state.func )
+				'foo'.should.eql localCache.get( 'key' )
+				return
 
 	describe "Issues", () ->
 		describe("#151 - cannot set null", () ->


### PR DESCRIPTION
Implemented `fetch` method similar to the one used in Rails caching.

[About fetch method in Rails caching](https://guides.rubyonrails.org/caching_with_rails.html#low-level-caching)
> This method does both reading and writing to the cache. When passed only a single argument, the key is fetched and value from the cache is returned. If a block is passed, that block will be executed in the event of a cache miss. The return value of the block will be written to the cache under the given cache key, and that return value will be returned. In case of cache hit, the cached value will be returned without executing the block.

Example Usage:

```javascript
localCache.fetch(key, ttl, function() {
  value = getSomething();
  return value;
});
```
