### PR TITLE
Add type definition for fetch method

### DIFF
--- a/_src/lib/node_cache.coffee
+++ b/_src/lib/node_cache.coffee
@@ -218,6 +218,9 @@ module.exports = class NodeCache extends EventEmitter
 		_ret = @get( key )
 		if _ret?
 			return _ret
+		if typeof value == 'undefined'
+			value = ttl
+			ttl = undefined
 		_ret = if typeof value == 'function' then value() else value
 		@set( key, _ret, ttl )
 		return _ret

--- a/_src/lib/node_cache.coffee
+++ b/_src/lib/node_cache.coffee
@@ -205,11 +205,11 @@ module.exports = class NodeCache extends EventEmitter
 	#
 	# * `key` ( String | Number ): cache key
 	# * `[ ttl ]` ( Number | String ): ( optional ) The time to live in seconds.
-	# * `value` ( Function | Any ): if Function is given, its return value will be fetched, otherwise the value itself is fetched
+	# * `value` ( Any ): if `Function` type is given, it will be executed and returned value will be fetched, otherwise the value itself is fetched
 	#
 	# **Example:**
 	#
-	#	myCache.fetch "myKey", 10, () => "my_String value"
+	# myCache.fetch "myKey", 10, () => "my_String value"
 	#
 	# myCache.fetch "myKey", "my_String value"
 	#

--- a/_src/lib/node_cache.coffee
+++ b/_src/lib/node_cache.coffee
@@ -215,9 +215,8 @@ module.exports = class NodeCache extends EventEmitter
 	#
 	fetch: ( key, ttl, value )=>
 		# check if cache is hit
-		_ret = @get( key )
-		if _ret?
-			return _ret
+		if @has( key )
+			return @get( key )
 		if typeof value == 'undefined'
 			value = ttl
 			ttl = undefined

--- a/_src/lib/node_cache.coffee
+++ b/_src/lib/node_cache.coffee
@@ -197,6 +197,30 @@ module.exports = class NodeCache extends EventEmitter
 		# return true
 		return true
 	
+	# ## fetch
+	#
+	# in the event of a cache miss (no value is assinged to given cache key), value will be written to cache and returned. In case of cache hit, cached value will be returned without executing given value. If the given value is type of `Function`, it will be executed and returned result will be fetched
+	#
+	# **Parameters:**
+	#
+	# * `key` ( String | Number ): cache key
+	# * `[ ttl ]` ( Number | String ): ( optional ) The time to live in seconds.
+	# * `value` ( Function | Any ): if Function is given, its return value will be fetched, otherwise the value itself is fetched
+	#
+	# **Example:**
+	#
+	#	myCache.fetch "myKey", 10, () => "my_String value"
+	#
+	# myCache.fetch "myKey", "my_String value"
+	#
+	fetch: ( key, ttl, value )=>
+		# check if cache is hit
+		_ret = @get( key )
+		if _ret?
+			return _ret
+		_ret = if typeof value == 'function' then value() else value
+		@set( key, _ret, ttl )
+		return _ret
 
 	# ## mset
 	#

--- a/_src/test/mocha_test.coffee
+++ b/_src/test/mocha_test.coffee
@@ -1252,6 +1252,11 @@ describe "`#{pkg.name}@#{pkg.version}` on `node@#{process.version}`", () ->
 				'foo'.should.eql localCache.fetch( 'key', 100, state.func )
 				'foo'.should.eql localCache.get( 'key' )
 				return
+		
+		context 'when ttl is omitted', () ->
+		  it 'swap ttl and value', () ->
+			  'foo'.should.eql localCache.fetch( 'key', state.func )
+				return
 
 	describe "Issues", () ->
 		describe("#151 - cannot set null", () ->

--- a/_src/test/mocha_test.coffee
+++ b/_src/test/mocha_test.coffee
@@ -1223,6 +1223,35 @@ describe "`#{pkg.name}@#{pkg.version}` on `node@#{process.version}`", () ->
 			return
 
 		return
+  
+	describe "fetch", () ->
+		beforeEach () ->
+				localCache.flushAll()
+				state =
+					func: () -> 
+						return 'foo'
+		
+		context 'when value is type of Function', () ->
+			it 'execute it and fetch returned value', () ->
+				'foo'.should.eql localCache.fetch( 'key', 100, state.func )
+				return
+
+		context 'when value is not a function', () ->
+			it 'return the value itself', () ->
+				'bar'.should.eql localCache.fetch( 'key', 100, 'bar' )
+				return
+
+		context 'cache hit', () ->
+			it 'return cached value', () ->
+				localCache.set 'key', 'bar', 100
+				'bar'.should.eql localCache.fetch( 'key', 100, state.func )
+				return
+
+		context 'cache miss', () ->
+			it 'write given value to cache and return it', () ->
+				'foo'.should.eql localCache.fetch( 'key', 100, state.func )
+				'foo'.should.eql localCache.get( 'key' )
+				return
 
 	describe "Issues", () ->
 		describe("#151 - cannot set null", () ->

--- a/_src/test/mocha_test.coffee
+++ b/_src/test/mocha_test.coffee
@@ -1223,7 +1223,7 @@ describe "`#{pkg.name}@#{pkg.version}` on `node@#{process.version}`", () ->
 			return
 
 		return
-  
+
 	describe "fetch", () ->
 		beforeEach () ->
 				localCache.flushAll()
@@ -1254,8 +1254,8 @@ describe "`#{pkg.name}@#{pkg.version}` on `node@#{process.version}`", () ->
 				return
 		
 		context 'when ttl is omitted', () ->
-		  it 'swap ttl and value', () ->
-			  'foo'.should.eql localCache.fetch( 'key', state.func )
+			it 'swap ttl and value', () ->
+				'foo'.should.eql localCache.fetch( 'key', state.func )
 				return
 
 	describe "Issues", () ->

--- a/_src/test/typedefinition_test.ts
+++ b/_src/test/typedefinition_test.ts
@@ -47,6 +47,22 @@ interface TypeSample {
 
 {
 	let cache: NodeCache;
+	let key: string;
+	let ttl: number | string;
+	let result: TypeSample;
+	let func = (): TypeSample => {
+		return {
+			a: 1,
+			b: 'foo',
+			c: true
+		};
+	};
+	result = cache.fetch<TypeSample>(key, func);
+	result = cache.fetch<TypeSample>(key, ttl, func);
+}
+
+{
+	let cache: NodeCache;
 	let keys: string | string[];
 	let result: number;
 	result = cache.del(keys);

--- a/index.d.ts
+++ b/index.d.ts
@@ -290,6 +290,24 @@ declare class NodeCache extends events.EventEmitter {
 	): boolean;
 
 	/**
+	 * in the event of a cache miss (no value is assinged to given cache key), value will be written to cache and returned. In case of cache hit, cached value will be returned without executing given value. If the given value is type of `Function`, it will be executed and returned result will be fetched
+	 * 
+	 * @param key cache key
+	 * @param ttl The time to live in seconds.
+	 * @param value function that returns a value to be stored in cache, or the value itself
+	 */
+	fetch<T>(
+		key: Key,
+		ttl: number | string,
+		value: () => T | T,
+  ): T;
+
+	fetch<T>(
+		key: Key,
+		value: () => T | T,
+	): T;
+
+	/**
 	 * set multiple cached keys at once and change the stats
 	 *
 	 * @param keyValueSet an array of object which includes key,value and ttl

--- a/index.d.ts
+++ b/index.d.ts
@@ -299,12 +299,12 @@ declare class NodeCache extends events.EventEmitter {
 	fetch<T>(
 		key: Key,
 		ttl: number | string,
-		value: () => T | T,
+		value: () => T,
   ): T;
 
 	fetch<T>(
 		key: Key,
-		value: () => T | T,
+		value: () => T,
 	): T;
 
 	/**


### PR DESCRIPTION
Pull request #202 has been closed due to https://github.com/node-cache/node-cache/pull/202#issuecomment-671756543

This pull request will commit:

- `fetch` method in PR #202
- Type definition for `fetch` method
- Test for `fetch` type
- Fix variable swap in `fetch` method when ttl option is missing