### PR TITLE
Added callback method in the flush all method. Use case.

### DIFF
--- a/_src/lib/node_cache.coffee
+++ b/_src/lib/node_cache.coffee
@@ -479,7 +479,7 @@ module.exports = class NodeCache extends EventEmitter
 
 	# ## flushAll
 	#
-	# flush the whole data and reset the stats
+	# flush the whole data and reset the stats, additionally you can pass the object that you need when 'flush' is emitted. For ex: in case of response that you want to send after success or failure.
 	#
 	# **Example:**
 	#
@@ -494,7 +494,7 @@ module.exports = class NodeCache extends EventEmitter
 	#     # vsize: 0
 	#     # }
 	#
-	flushAll: ( _startPeriod = true )=>
+	flushAll: ( _startPeriod = true, obj )=>
 		# parameter just for testing
 
 		# set data empty
@@ -512,7 +512,7 @@ module.exports = class NodeCache extends EventEmitter
 		@_killCheckPeriod()
 		@_checkData( _startPeriod )
 
-		@emit( "flush" )
+		@emit( "flush", obj )
 
 		return
 	


### PR DESCRIPTION
If a client wants to clear the cache on the server and get success after flush and other operations or errors if something goes wrong. I should be able to pass the response object in the flush all to receive it when it's successful.

Ref : https://github.com/node-cache/node-cache/issues/259