### PR TITLE
fix: #263 forceString invalid implementation

### DIFF
--- a/_src/lib/node_cache.coffee
+++ b/_src/lib/node_cache.coffee
@@ -164,7 +164,7 @@ module.exports = class NodeCache extends EventEmitter
 			throw _err
 
 		# force the data to string
-		if @options.forceString and not typeof value is "string"
+		if @options.forceString and typeof value isnt "string"
 			value = JSON.stringify( value )
 
 		# set default ttl if not passed

--- a/_src/test/mocha_test.coffee
+++ b/_src/test/mocha_test.coffee
@@ -1303,5 +1303,28 @@ describe "`#{pkg.name}@#{pkg.version}` on `node@#{process.version}`", () ->
 			return
 		)
 
+		describe("#263 - forceString never works", () ->
+			cache = null
+			before(() ->
+				cache = new nodeCache({
+			    forceString: true
+			  })
+				return
+			)
+
+			it("set the value `null` - this should transform into a string", () -> 
+			  cache.set "test", null
+			  should(cache.get("test")).eql("null")
+			  return
+			)
+
+			it("set the value `{ hello: 'World' }` - this should transform into a string", () -> 
+			  cache.set "test", { hello: 'World' }
+			  should(cache.get("test")).eql("{\"hello\":\"World\"}")
+			  return
+			)
+			return
+		)
+
 		return
 	return

--- a/_src/test/mocha_test.coffee
+++ b/_src/test/mocha_test.coffee
@@ -1307,21 +1307,21 @@ describe "`#{pkg.name}@#{pkg.version}` on `node@#{process.version}`", () ->
 			cache = null
 			before(() ->
 				cache = new nodeCache({
-			    forceString: true
-			  })
+					forceString: true
+				})
 				return
 			)
 
 			it("set the value `null` - this should transform into a string", () -> 
-			  cache.set "test", null
-			  should(cache.get("test")).eql("null")
-			  return
+				cache.set "test", null
+				should(cache.get("test")).eql("null")
+				return
 			)
 
 			it("set the value `{ hello: 'World' }` - this should transform into a string", () -> 
-			  cache.set "test", { hello: 'World' }
-			  should(cache.get("test")).eql("{\"hello\":\"World\"}")
-			  return
+				cache.set "test", { hello: 'World' }
+				should(cache.get("test")).eql("{\"hello\":\"World\"}")
+				return
 			)
 			return
 		)


### PR DESCRIPTION
Closes #263

I started reading the generated code in javascript to understand something about the library, then my linter shows a simple type error. I see in issues and find #263 that target this. I read the [docs of coffescript](http://coffeescript.org/#operators) looking by the 'isnt' operator, that I think will solve this. I create basic tests to check that.
