### PR TITLE
#225 refactor: return default object if defined and cache is empty

### DIFF
--- a/_src/lib/node_cache.coffee
+++ b/_src/lib/node_cache.coffee
@@ -89,7 +89,7 @@ module.exports = class NodeCache extends EventEmitter
 	#
 	#	myCache.get "myKey", ( err, val )
 	#
-	get: ( key )=>
+	get: ( key, defaultObj = null )=>
 		# handle invalid key types
 		if (err = @_isInvalidKey( key ))?
 			throw err
@@ -101,9 +101,9 @@ module.exports = class NodeCache extends EventEmitter
 			# return data
 			return _ret
 		else
-			# if not found return undefined
+			# if not found return defaultObj otherwise undefined
 			@stats.misses++
-			return undefined
+			return defaultObj || undefined
 
 	# ## mget
 	#

--- a/_src/test/mocha_test.coffee
+++ b/_src/test/mocha_test.coffee
@@ -1326,5 +1326,19 @@ describe "`#{pkg.name}@#{pkg.version}` on `node@#{process.version}`", () ->
 			return
 		)
 
+		describe("#255 - get with default value", () ->
+			cache = null
+			before(() ->
+				cache = new nodeCache()
+				return
+			)
+
+			it("should return default value if cache is empty and default object defined", () ->
+				should(cache.get("test", defaultObj={test: true})).eql({test: true})
+				return
+			)
+			return
+		)
+
 		return
 	return


### PR DESCRIPTION
Motivation:
I used the library and needed the default value to prevent adding extra conditions to check `undefined`.

This PR aims to allow default object for the empty cache. 
Related tests added to cover changes.

Related Issue: #225 